### PR TITLE
Timeline scrolling

### DIFF
--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -3,7 +3,7 @@
     <a :href="card.url" rel="nofollow noopener" target="_blank">
       <img v-if="card.image" :src="card.image" />
       <h1>{{ card.title }}</h1>
-      <p v-if="card.description.length > 0">{{ card.description }}</p>
+      <p v-if="description">{{ description }}</p>
       <div v-if="card.type === 'video'" v-html="card.html" />
     </a>
   </section>
@@ -12,7 +12,15 @@
 <script>
 export default {
   name: 'Card',
-  props: ['card']
+  props: ['card'],
+  computed: {
+    description () {
+      if (typeof this.card.description !== 'undefined' &&
+          this.card.description.length > 0) {
+        return this.card.description
+      }
+    }
+  }
 }
 </script>
 

--- a/src/components/OneStatus.vue
+++ b/src/components/OneStatus.vue
@@ -27,6 +27,7 @@
 <script>
 import * as Moment from 'moment'
 import Card from '@/components/Card'
+import config from '@/lib/config'
 export default {
   name: 'OneStatus',
   props: ['status'],
@@ -88,7 +89,7 @@ export default {
     fetchCard (attempts = 0) {
       // console.log('Fetching card for toot#' + this.status.id)
       this.$http
-          .get('https://pawoo.net/api/v1/statuses/' + this.status.id + '/card')
+          .get(config.instance + '/api/v1/statuses/' + this.status.id + '/card')
           .then(response => {
             if (response.body.url) {
               this.card = response.body

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -19,13 +19,13 @@ export default {
     return {
       statuses: [],
       newStatuses: [],
-      timeline: 'home'
+      scrolled: false
     }
   },
+  props: ['timeline'],
   watch: {
-    '$route' (to, from) {
+    timeline (to, from) {
       console.log('Changed route!')
-      this.timeline = to.name.toLowerCase()
       this.statuses = this.newStatuses = []
       this.socket.close()
       this.startStream()

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -1,7 +1,6 @@
 <template>
   <div>
     <new-toot/>
-    <div>Currently racing past at {{tpm}} toot/min!</div>
     <ol>
       <li v-for="status in statuses" :key="status.id">
         <one-status :status.sync="status"></one-status>
@@ -19,24 +18,12 @@ export default {
   data () {
     return {
       statuses: [],
-      seen: 0,
-      now: Moment(),
       timeline: 'home'
-    }
-  },
-  computed: {
-    tpm () {
-      return Math.floor(
-        this.seen / Moment.duration(this.now.diff(this.started)).asMinutes()
-      )
     }
   },
   watch: {
     '$route' (to, from) {
       this.timeline = to.name.toLowerCase()
-      this.statuses = []
-      this.seen = 0
-      this.started = Moment()
       this.socket.close()
       this.startStream()
     }
@@ -65,8 +52,6 @@ export default {
         event.payload = JSON.parse(event.payload)
         switch (event.event) {
           case 'update':
-            this.seen++
-            this.now = Moment()
             this.statuses.unshift(event.payload)
             if (this.statuses.length > this.statusLimit) {
               this.statuses = this.statuses.slice(0, this.statusLimit)
@@ -88,7 +73,6 @@ export default {
   },
   created () {
     this.statusLimit = 20
-    this.started = Moment()
     this.token = JSON.parse(localStorage.getItem('token'))
     let instance = JSON.parse(localStorage.getItem('instance'))
     let base = instance + '/api/v1'

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -12,7 +12,7 @@
 <script>
 import OneStatus from '@/components/OneStatus'
 import NewToot from '@/components/NewToot'
-import * as Moment from 'moment'
+import config from '@/lib/config'
 export default {
   name: 'Timeline',
   data () {
@@ -36,7 +36,7 @@ export default {
       let endpoint = this.endpoints.rest[this.timeline]
       return this.$http.get(endpoint, {
         params: { limit: this.statusLimit },
-        headers: { Authorization: 'Bearer ' + this.token }
+        headers: { Authorization: 'Bearer ' + config.token }
       }).then(response => {
         var result = JSON.parse(response.bodyText)
         this.statuses = result
@@ -53,8 +53,8 @@ export default {
         switch (event.event) {
           case 'update':
             this.statuses.unshift(event.payload)
-            if (this.statuses.length > this.statusLimit) {
-              this.statuses = this.statuses.slice(0, this.statusLimit)
+            if (this.statuses.length > config.statusLimit) {
+              this.statuses = this.statuses.slice(0, config.statusLimit)
             }
             break
           case 'delete':
@@ -72,13 +72,10 @@ export default {
     OneStatus
   },
   created () {
-    this.statusLimit = 20
-    this.token = JSON.parse(localStorage.getItem('token'))
-    let instance = JSON.parse(localStorage.getItem('instance'))
-    let base = instance + '/api/v1'
+    let base = config.instance + '/api/v1'
     let apiBase = base + '/timelines'
     let streamBase = base.replace(/^https?/i, 'ws') +
-                     '/streaming?access_token=' + this.token + '&stream='
+                     '/streaming?access_token=' + config.token + '&stream='
     this.endpoints = {
       rest: {
         home: apiBase + '/home',

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <new-toot/>
+    <button v-if="scrolled" @click="restartStream">Catch up at once!</button>
     <ol>
       <li v-for="status in statuses" :key="status.id">
         <one-status :status.sync="status"></one-status>
@@ -40,7 +41,9 @@ export default {
       if (this.socket && typeof this.socket.close === 'function') {
         this.socket.close()
       }
+      this.scrolled = true
       if (el.scrollTop === 0) {
+        this.scrolled = false
         this.readUp()
       } else if (el.scrollTop + el.clientHeight >= el.offsetHeight) {
         this.readDown()
@@ -69,6 +72,8 @@ export default {
         // restart stream if reached top
         if (this.newStatuses.length < config.scrollLimit) {
           this.stream()
+        } else {
+          window.scrollTo(0, 10)
         }
       })
     },
@@ -108,6 +113,10 @@ export default {
     },
     startStream () {
       this.readDown().then(this.stream)
+    },
+    restartStream () {
+      window.scrollTo(0, 0)
+      this.startStream()
     }
   },
   components: {

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -1,0 +1,5 @@
+export default {
+  statusLimit: 20,
+  token: JSON.parse(localStorage.getItem('token')),
+  instance: JSON.parse(localStorage.getItem('instance'))
+}

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -1,5 +1,6 @@
 export default {
   statusLimit: 20,
+  scrollLimit: 10,
   token: JSON.parse(localStorage.getItem('token')),
   instance: JSON.parse(localStorage.getItem('instance'))
 }

--- a/src/lib/router.js
+++ b/src/lib/router.js
@@ -10,17 +10,20 @@ export default new Router({
     {
       path: '/',
       name: 'Home',
-      component: Timeline
+      component: Timeline,
+      props: { timeline: 'home' }
     },
     {
       path: '/local',
       name: 'Local',
-      component: Timeline
+      component: Timeline,
+      props: { timeline: 'local' }
     },
     {
       path: '/fed',
       name: 'Fed',
-      component: Timeline
+      component: Timeline,
+      props: { timeline: 'fed' }
     },
     {
       path: '/login',


### PR DESCRIPTION
## Changes
- move common settings to config.js
- fix routes passing props (instead of watching route change)
  otherwise reload would always reset to home route
- made `card.description` a computed property
  it appears to have been missing on some instances
- remove TPM counting
- handle scrolling (ref issue)
- added catch-up button

## Issue
#17