### PR TITLE
Threading and replies

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -98,4 +98,12 @@ button {
   border: 1px solid #999;
   border-radius: 1em;
 }
+
+.invisible {
+  display: none;
+}
+
+.ellipsis:after {
+  content: '…';
+}
 </style>

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -17,8 +17,28 @@ export default {
     description () {
       if (typeof this.card.description !== 'undefined' &&
           this.card.description.length > 0) {
-        return this.card.description
+        return this.truncate(this.card.description)
       }
+    }
+  },
+  methods: {
+    truncate (str) {
+      let max = 150
+      if (typeof str !== 'string' || str.length <= max) {
+        return str
+      }
+      let mid = /[\s?!.\u3000-\u303f]/u // range of cjk punctuation
+      var broken = false
+      const merge = (acc, curr) => {
+        let ifAdded = acc.length + curr.length
+        if (!broken && ifAdded < max) {
+          return acc + curr + (str[ifAdded] ? str[ifAdded] : '')
+        } else {
+          broken = true
+          return acc
+        }
+      }
+      return str.split(mid).reduce(merge, '')
     }
   }
 }

--- a/src/components/Convo.vue
+++ b/src/components/Convo.vue
@@ -1,0 +1,84 @@
+<template>
+  <div>
+    <ol v-if="ancestors.length">
+      <li v-for="status in ancestors" :key="status.id">
+        <one-status :status="status" />
+      </li>
+    </ol>
+    <one-status v-if="coreStatus.id" :status="coreStatus" :passedCard="coreCard" />
+    <ol v-if="descendants.length">
+      <li v-for="status in descendants" :key="status.id">
+        <one-status :status="status" />
+      </li>
+    </ol>
+  </div>
+</template>
+
+<script>
+import OneStatus from '@/components/OneStatus'
+import config from '@/lib/config'
+export default {
+  name: 'Convo',
+  components: {
+    OneStatus
+  },
+  data () {
+    return {
+      ancestors: [],
+      descendants: [],
+      coreStatus: {},
+      coreCard: {}
+    }
+  },
+  computed: {
+    id () {
+      return this.$route.params.id
+    },
+    endpoint () {
+      return config.instance + '/api/v1/statuses/' + this.id
+    },
+    context () {
+      return this.endpoint + '/context'
+    }
+  },
+  watch: {
+    id (from, to) {
+      if (from === to) {
+        return true
+      }
+      this.init()
+    }
+  },
+  methods: {
+    init () {
+      this.ancestors = []
+      this.descendants = []
+      if (!this.$root.$data.store.opened || !this.$root.$data.store.opened.status) {
+        this.$http.get(this.endpoint, {
+          headers: { Authorization: 'Bearer ' + config.token }
+        }).then(response => {
+          this.coreStatus = response.body
+        }, response => console.log(response))
+      } else {
+        this.coreStatus = this.$root.$data.store.opened.status
+        this.coreCard = this.$root.$data.store.opened.card
+      }
+      this.$http.get(this.context, {
+        headers: { Authorization: 'Bearer ' + config.token }
+      }).then(response => {
+        this.ancestors = response.body.ancestors
+        this.descendants = response.body.descendants
+      }, response => console.log(response))
+    }
+  },
+  created () {
+    this.init()
+  }
+}
+</script>
+
+<style scoped>
+ol {
+  list-style: none outside none;
+}
+</style>

--- a/src/components/Convo.vue
+++ b/src/components/Convo.vue
@@ -2,13 +2,15 @@
   <div>
     <ol v-if="ancestors.length">
       <li v-for="status in ancestors" :key="status.id">
-        <one-status :status="status" />
+        <one-status :status="status" @deleteToot="deleteSuccess" />
       </li>
     </ol>
-    <one-status v-if="coreStatus.id" :status="coreStatus" :passedCard="coreCard" />
+    <one-status v-if="coreStatus.id" @deleteToot="deleteSuccess"
+                :status="coreStatus" :passedCard="coreCard" />
+    <new-toot :replyTo="coreStatus" @newToot="postSuccess" />
     <ol v-if="descendants.length">
       <li v-for="status in descendants" :key="status.id">
-        <one-status :status="status" />
+        <one-status :status="status" @deleteToot="deleteSuccess" />
       </li>
     </ol>
   </div>
@@ -16,11 +18,12 @@
 
 <script>
 import OneStatus from '@/components/OneStatus'
+import NewToot from '@/components/NewToot'
 import config from '@/lib/config'
 export default {
   name: 'Convo',
   components: {
-    OneStatus
+    OneStatus, NewToot
   },
   data () {
     return {
@@ -50,6 +53,17 @@ export default {
     }
   },
   methods: {
+    postSuccess (status) {
+      this.descendants.unshift(status)
+    },
+    deleteSuccess (id) {
+      if (id === this.id) {
+        this.$route.push('Home')
+      }
+      const notThis = (item) => item.id !== id
+      this.descendants = this.descendants.filter(notThis)
+      this.ancestors = this.ancestors.filter(notThis)
+    },
     init () {
       this.ancestors = []
       this.descendants = []

--- a/src/components/NewToot.vue
+++ b/src/components/NewToot.vue
@@ -30,9 +30,10 @@ export default {
   },
   methods: {
     send () {
-      if (!this.message.length && !this.uploads.length) {
+      if (this.sending || (!this.message.length && !this.uploads.length)) {
         return true
       }
+      this.sending = true
       this.$http.post(this.endpoints.toot, {
         status: this.message,
         media_ids: this.uploads.slice(0, 4).map(upload => upload.id)
@@ -41,6 +42,7 @@ export default {
       }).then(response => {
         this.message = ''
         this.uploads = []
+        this.sending = false
         this.$emit('newToot', response.body)
       }, response => console.log('Request failed.'))
     },
@@ -50,7 +52,6 @@ export default {
         return true
       }
       [...files].map(this.uploadOne)
-      files = []
     },
     onPaste (e) {
       if (!e.clipboardData.items || this.uploads.length > 3) {

--- a/src/components/OneStatus.vue
+++ b/src/components/OneStatus.vue
@@ -2,8 +2,8 @@
   <article>
     <div>
       <div v-if="reblog">Boosted by
-        <a :href="booster.url">{{ booster.display_name }}</a></div>
-      <a :href="author.url">{{ author.display_name }}</a>
+        <a :href="booster.url">{{ booster.display_name || booster.username }}</a></div>
+      <a :href="author.url">{{ author.display_name || author.username }}</a>
       <a :href="orBoosted.url" :title="fullTime">{{ displayTime }}</a>
     </div>
     <section v-if="orBoosted.spoiler_text" v-html="orBoosted.spoiler_text"></section>

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <new-toot/>
+    <new-toot :replyTo="{}" />
     <button v-if="scrolled" @click="restartStream">Catch up at once!</button>
     <ol @deleteToot="deleteToot" @newToot="newToot">
       <li v-for="status in statuses" :key="status.id">

--- a/src/lib/router.js
+++ b/src/lib/router.js
@@ -1,11 +1,13 @@
 import Vue from 'vue'
 import Router from 'vue-router'
 import Timeline from '@/components/Timeline'
+import Convo from '@/components/Convo'
 import Login from '@/components/Login'
 
 Vue.use(Router)
 
 export default new Router({
+  hashbang: false,
   routes: [
     {
       path: '/',
@@ -29,6 +31,11 @@ export default new Router({
       path: '/login',
       name: 'Login',
       component: Login
+    },
+    {
+      path: '/convo/:id',
+      name: 'Convo',
+      component: Convo
     }
   ]
 })


### PR DESCRIPTION
## Changes
* open single toot's thread in separate route
* reply to toot
* move back to Home route if focused toot in Convo gets deleted

## Bugfix
* only load card if there are no images (same as twitter/mastodon)
* moved certain styles back to App (they aren't effective otherwise)
* prevent doubly sending toots
* truncate card description (there were a few ridiculously long ones)
* fall back to `username` if `display_name` is empty
* prevent id collision error (this time for real)

## Note
Messed up the commits. Sorry about that.
  